### PR TITLE
Add support for macOS notmuch configuration paths

### DIFF
--- a/notmuch-indicator.el
+++ b/notmuch-indicator.el
@@ -169,6 +169,8 @@ option `notmuch-indicator-refresh-count'."
   "Return `notmuch' configuration file."
   (catch 'found
     (dolist (path '("$XDG_CONFIG_HOME/notmuch/$NOTMUCH_PROFILE/config"
+                    "$HOME/.config/notmuch/$NOTMUCH_PROFILE/config"
+                    "$HOME/.config/notmuch/default/config"
                     "$HOME/.notmuch-config.$NOTMUCH_PROFILE"
                     "$HOME/.notmuch-config"))
       (when-let* ((config (substitute-env-vars path))


### PR DESCRIPTION
This change adds two fallback paths to handle these common macOS scenarios:

-   `$HOME/.config/notmuch/$NOTMUCH_PROFILE/config` (handles when `$NOTMUCH_PROFILE` is defined)
-   `$HOME/.config/notmuch/default/config` (fallbacks to the `default` profile when `$NOTMUCH_PROFILE` is undefined)

### Background
According to the notmuch documentation at <https://notmuchmail.org/doc/latest/man1/notmuch-config.html#configuration>, notmuch looks for configuration files at:

> `$XDG_CONFIG_HOME/notmuch/<profile>/config` where `<profile>` is defined by `NOTMUCH_PROFILE` environment variable if set, `$XDG_CONFIG_HOME/notmuch/default/config` otherwise.

On macOS, `$XDG_CONFIG_HOME` is typically undefined, but the [XDG Base Directory](https://wiki.archlinux.org/title/XDG_Base_Directory) specification convention uses `~/.config` as the fallback. Additionally, when `$NOTMUCH_PROFILE` is undefined, it defaults to `default`.